### PR TITLE
dev > main

### DIFF
--- a/src/PayWall.NetCore/PayWall.NetCore.csproj
+++ b/src/PayWall.NetCore/PayWall.NetCore.csproj
@@ -4,7 +4,7 @@
         <TargetFrameworks>net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
         <Authors>PayWall</Authors>
         <PackageId>PayWall.NetCore</PackageId>
-        <Version>0.0.7</Version>
+        <Version>0.0.8</Version>
         <Product>PayWall.NetCore</Product>
         <ImplicitUsings>disable</ImplicitUsings>
         <Nullable>disable</Nullable>

--- a/src/PayWall.NetCore/ServiceCollectionExtensions.cs
+++ b/src/PayWall.NetCore/ServiceCollectionExtensions.cs
@@ -54,6 +54,19 @@ namespace PayWall.NetCore
                 .AddMemberApiClient(payWallOptions, handlerFactories)
                 .AddTransient<PayWallService>();
         }
+        
+        public static void AddPaywallService(
+            this IServiceCollection services,
+            PayWallOptions payWallOptions,
+            params Func<IServiceProvider, DelegatingHandler>[] handlerFactories)
+        {
+            services
+                .AddPaymentApiClient(payWallOptions, handlerFactories)
+                .AddPaymentPrivateApiClient(payWallOptions, handlerFactories)
+                .AddCardWallApiClient(payWallOptions, handlerFactories)
+                .AddMemberApiClient(payWallOptions, handlerFactories)
+                .AddTransient<PayWallService>();
+        }
         #endregion
 
         #region Private Methods


### PR DESCRIPTION
This pull request introduces a version update and adds a new overload for the `AddPaywallService` method to enhance flexibility in configuring the PayWall service.

### Version Update:
* Updated the version in `src/PayWall.NetCore/PayWall.NetCore.csproj` from `0.0.7` to `0.0.8`. This reflects the new changes and improvements made to the library.

### API Enhancements:
* Added a new overload for the `AddPaywallService` method in `src/PayWall.NetCore/ServiceCollectionExtensions.cs`. This overload allows for more flexible configuration by accepting `PayWallOptions` and an array of `DelegatingHandler` factories, enabling the addition of multiple API clients (`PaymentApiClient`, `PaymentPrivateApiClient`, `CardWallApiClient`, and `MemberApiClient`) with custom handlers.